### PR TITLE
Adding simple version of Transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,21 @@ key = 'edf9aee84d9b7abc145504dde6726c64f369d37ee34ded868fabd876c26570bc'
 signature_data = encryption.sign_message_hash_rsv(hex_dig, key)
 print(signature_data)
 ```
+
+Example code for transactions:
+
+```
+from network import StacksTestnet
+from transactions import make_stx_token_transfer
+network = StacksTestnet()
+tx_options = {
+    "recipient": 'ST319CF5WV77KYR1H3GT0GZ7B8Q4AQPY42ETP1VPF',
+    "sender_key": "b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01",
+    "network": network,
+    "memo": "hello from python",
+    "amount": 10
+}
+
+transaction = make_stx_token_transfer(tx_options)
+print(transaction.serialize().hex())
+```

--- a/stackspy/authorization.py
+++ b/stackspy/authorization.py
@@ -1,0 +1,84 @@
+from typing import Dict
+import copy
+from common.helpers import sha512_256
+from encryption import sign_with_key
+from constants import RECOVERABLE_ECDSA_SIG_LENGTH_BYTES, AuthType
+from common.helpers import is_hex_addy_compressed, left_pad_hex, is_single_sig, empty_signature_message, create_standard_auth
+from common.helpers import pub_key_from_priv_key
+
+def make_sig_hash_pre_sign(cur_sig_hash, auth_type, fee, nonce):
+    # new hash combines the previous hash and all the new data this signature will add. This
+    # includes:
+    # * the previous hash
+    # * the auth flag
+    # * the tx fee (big-endian 8-byte number)
+    # * nonce (big-endian 8-byte number)
+    hash_length = 32 + 1 + 8 + 8    
+    sig_hash = cur_sig_hash + auth_type.to_bytes(1, 'big').hex() + fee.to_bytes(8, 'big').hex() + nonce.to_bytes(8, 'big').hex()
+    if len(bytearray.fromhex(sig_hash)) != hash_length:
+        raise ValueError('Invalid signature hash length')
+    return sha512_256(bytearray.fromhex(sig_hash))
+
+
+def make_sig_hash_post_sign(cur_sig_hash: str, pub_key: str, signature: str) -> str:
+    """
+    Create a signature hash after signing.
+    :param cur_sig_hash: Current signature hash as a string.
+    :param pub_key: Public key as a string.
+    :param signature: Message signature as a string.
+    :return: Signature hash as a string.
+    """
+    # new hash combines the previous hash and all the new data this signature will add.  This
+    # includes:
+    # * the public key compression flag
+    # * the signature
+    hash_length = 32 + 1 + RECOVERABLE_ECDSA_SIG_LENGTH_BYTES
+
+    pub_key_encoding = 1 if is_hex_addy_compressed(pub_key) else 0  # Assuming 1: Compressed, 0: Uncompressed
+
+    sig_hash = cur_sig_hash + left_pad_hex(hex(pub_key_encoding)[2:]) + signature
+
+    if len(bytearray.fromhex(sig_hash)) > hash_length:
+        raise ValueError('Invalid signature hash length')
+
+    return sha512_256(bytearray.fromhex(sig_hash))
+
+def next_signature(cur_sig_hash: str, auth_type: str, fee: int, nonce: int, private_key: str) -> Dict[str, str]:
+    sig_hash_pre_sign = make_sig_hash_pre_sign(cur_sig_hash, auth_type, fee, nonce) #this works lets fucking go.
+    signature = sign_with_key(sig_hash_pre_sign.hex(), private_key["data"])
+    public_key = pub_key_from_priv_key(private_key["data"])
+    next_sig_hash = make_sig_hash_post_sign(sig_hash_pre_sign.hex(), public_key, signature["data"])
+    return {
+        'nextSig': signature,
+        'nextSigHash': next_sig_hash.hex()
+    }
+
+def clear_condition(spending_condition):
+    cloned_condition =  copy.deepcopy(spending_condition)
+    cloned_condition["nonce"] = 0
+    cloned_condition["fee"] = 0
+
+    if is_single_sig(cloned_condition):
+        cloned_condition["signature"] = empty_signature_message()
+    else:
+        # no single TODO
+        cloned_condition["fields"] = []
+
+    return cloned_condition
+
+def into_initial_sighash_auth(auth):
+    """
+    Convert the given authorization into its initial sighash form.
+    :param auth: The Authorization object.
+    :return: The Authorization in its initial sighash form.
+    """
+    if auth["spendingCondition"]:
+        if auth["authType"] == AuthType.Standard:
+            return create_standard_auth(clear_condition(auth["spendingCondition"]))
+        elif auth["authTyp"] == AuthType.Sponsored:
+            pass
+        else:
+            raise ValueError('Unexpected authorization type for signing')
+    
+    raise ValueError('Authorization missing SpendingCondition')
+

--- a/stackspy/common/StacksTransaction.py
+++ b/stackspy/common/StacksTransaction.py
@@ -1,3 +1,9 @@
+import copy
+from constants import AuthType
+from authorization import next_signature, into_initial_sighash_auth
+from .clarity import serialize_cv
+from .helpers import PayloadType, serialize_memo_string, is_single_sig, sha512_256
+
 class StacksTransaction:
     def __init__(self, version, auth, payload, post_conditions=None, post_condition_mode=None, anchor_mode=None, chain_id=None):
         self.version = version
@@ -9,7 +15,20 @@ class StacksTransaction:
         self.anchor_mode = anchor_mode
 
     def sign_begin(self):
-        pass
+        tx = copy.deepcopy(self)
+        tx.auth = into_initial_sighash_auth(tx.auth)
+        return tx.txid()
+
+    def sign_next_origin(self, sig_hash, priv_key):
+        if not self.auth["spendingCondition"]:
+            # error
+            pass
+
+        if not self.auth["authType"]:
+            # error
+            pass
+
+        return self.sign_and_append(self.auth["spendingCondition"], sig_hash, AuthType.Standard, priv_key)
 
     def verify_being(self):
         pass
@@ -27,22 +46,107 @@ class StacksTransaction:
         pass
 
     def sign_and_append(self, condition, cursig_hash, auth_type, private_key):
-        pass
+        next_sig_data = next_signature(
+            cursig_hash, auth_type.value, self.auth["spendingCondition"]["fee"], self.auth["spendingCondition"]["nonce"], private_key
+        )
+        if is_single_sig(condition):
+            self.auth["spendingCondition"]["signature"] = next_sig_data["nextSig"]
+        return next_sig_data["nextSigHash"]
 
     def txid(self):
-        pass
+        serialized = self.serialize();
+        return sha512_256(serialized).hex()
 
     def set_sponsor(self, sponsor_spending_condition):
         pass
 
     def set_fee(self, amount):
-        pass
+        if self.auth["authType"] == AuthType.Standard:
+            self.auth["spendingCondition"]["fee"] = amount
+        elif self.auth["authType"] == AuthType.Sponsored:
+            # TODO implement
+            pass
+
+
 
     def set_nonce(self, nonce):
-        pass
+        if self.auth["authType"] == AuthType.Standard:
+            self.auth["spendingCondition"]["nonce"] = nonce
+        elif self.auth["authType"] == AuthType.Sponsored:
+            # TODO implement
+            pass
 
     def set_sponsor_nonce(self, nonce):
         pass
 
+    def serialize_payload(self):
+        payload_bytes_array = bytearray()
+        payload_bytes_array.append(self.payload["payloadType"])
+
+        if self.payload["payloadType"] == PayloadType.TokenTransfer.value:
+            payload_bytes_array += serialize_cv(self.payload["recipient"])
+            payload_bytes_array += self.payload["amount"].to_bytes(8, 'big')
+            payload_bytes_array += serialize_memo_string(self.payload["memo"])
+
+        return payload_bytes_array
+        # TODO - implement other payload types
+
+    def serialize_single_sig_spending_condition(self, spending_condition):
+        bytes_array = bytearray()
+        bytes_array.append(spending_condition["hashMode"].value)
+        bytes_array += bytearray(bytes.fromhex(spending_condition["signer"]["hash160"]))
+        bytes_array += spending_condition["nonce"].to_bytes(8, 'big')
+        bytes_array += spending_condition["fee"].to_bytes(8, 'big')
+        bytes_array.append(spending_condition["keyEncoding"].value)
+        bytes_array += bytearray(bytes.fromhex(spending_condition["signature"]["data"]))
+        return bytes_array
+        
+    def serialize_spending_condition(self):
+        spending_condition = self.auth["spendingCondition"]
+        bytes_array = bytearray()
+        if is_single_sig(spending_condition):
+            bytes_array += self.serialize_single_sig_spending_condition(spending_condition)
+        else:
+            # TODO MultiSig
+            pass
+        return bytes_array
+
+    def serialize_authorization(self):
+        bytes_array = bytearray()
+        bytes_array.append(self.auth["authType"].value)
+        if self.auth["authType"] == AuthType.Standard:
+            bytes_array += self.serialize_spending_condition()
+        elif self.auth["authType"] == AuthType.Sponsored:
+            # TODO implement
+            pass
+        return bytes_array
+
     def serialize(self):
-        pass
+        if self.version is None:
+            raise ValueError('version is undefined')
+        
+        if self.chain_id is None:
+            raise ValueError('chain_id is undefined')
+
+        # Can be undefined for single sig with sender key?
+        # if not self.auth:
+        #     raise ValueError('auth is undefined')
+
+        # Can be undefined for single sig with sender key?
+        # if not self.anchor_mode:
+        #     raise ValueError('anchor_mode is undefined')                                    
+
+        if self.payload is None:
+            raise ValueError('payload is undefined')
+
+        bytes_array = bytearray()
+        bytes_array.append(self.version)
+        bytes_array += self.chain_id.to_bytes(4, 'big')
+        bytes_array += self.serialize_authorization()
+        bytes_array += bytearray(bytes.fromhex("03")) #HARD CODING anchor mode
+        bytes_array += bytearray(bytes.fromhex("02")) #HARD CODING postcondition mode
+        length_of_pc = 0
+        bytes_array += length_of_pc.to_bytes(4, 'big') #HARD CODING postconditons list
+        bytes_array += self.serialize_payload()
+
+        return bytes_array

--- a/stackspy/common/StacksTransaction.py
+++ b/stackspy/common/StacksTransaction.py
@@ -1,0 +1,48 @@
+class StacksTransaction:
+    def __init__(self, version, auth, payload, post_conditions=None, post_condition_mode=None, anchor_mode=None, chain_id=None):
+        self.version = version
+        self.auth = auth
+        self.payload = payload
+        self.chain_id = chain_id
+        self.post_condition_mode = post_condition_mode
+        self.post_conditions = post_conditions
+        self.anchor_mode = anchor_mode
+
+    def sign_begin(self):
+        pass
+
+    def verify_being(self):
+        pass
+
+    def verify_origin(self):
+        pass
+
+    def sign_nex_origin(self, sig_hash, private_key):
+        pass
+
+    def sign_next_sponsor(self, sig_hash, private_key):
+        pass
+
+    def append_pub_key(self, public_key):
+        pass
+
+    def sign_and_append(self, condition, cursig_hash, auth_type, private_key):
+        pass
+
+    def txid(self):
+        pass
+
+    def set_sponsor(self, sponsor_spending_condition):
+        pass
+
+    def set_fee(self, amount):
+        pass
+
+    def set_nonce(self, nonce):
+        pass
+
+    def set_sponsor_nonce(self, nonce):
+        pass
+
+    def serialize(self):
+        pass

--- a/stackspy/common/TransactionSigner.py
+++ b/stackspy/common/TransactionSigner.py
@@ -1,0 +1,30 @@
+from common.helpers import is_single_sig
+from transactions import StacksTransaction
+class TransactionSigner:
+    def __init__(self, transaction: StacksTransaction):
+        self.transaction = transaction
+        self.sig_hash = transaction.sign_begin()
+        self.origin_done = False
+        self.check_oversign = True
+        self.check_overlap = True
+
+        spending_condition = transaction.auth["spendingCondition"]
+        if spending_condition and not is_single_sig(spending_condition):
+            # TODO implmenet
+            pass
+    
+    def sign_origin(self, priv_key):
+        if self.check_overlap and self.origin_done:
+            raise ValueError('Cannot sign origin after sponsor key')
+
+        if self.transaction.auth is None:
+            raise ValueError('"transaction.auth" is undefined')
+        if self.transaction.auth["spendingCondition"] is None:
+            raise ValueError('"transaction.auth.spendingCondition" is undefined')
+
+        if not is_single_sig(self.transaction.auth["spendingCondition"]):
+            # TODO - Implement
+            pass
+
+        next_sig_hash = self.transaction.sign_next_origin(self.sig_hash, priv_key)
+        self.sig_hash = next_sig_hash

--- a/stackspy/common/c32helpers.py
+++ b/stackspy/common/c32helpers.py
@@ -13,7 +13,39 @@ def c32_checksum(data_hex):
 
 def c32_encode(hex_data_to_encode):
     return base32.encode(int(hex_data_to_encode, 16)).upper()
+
+def c32_decode(c32_data_to_decode):
+    return format(base32.decode(c32_data_to_decode), 'x')
+
+def c32_address_decode(c32_address):
+    if len(c32_address) <= 5:
+        raise ValueError('Invalid c32 address: invalid length')
+    if c32_address[0] != 'S':
+        raise ValueError('Invalid c32 address: must start with "S"')
     
+    return c32_check_decode(c32_address[1:])
+
+def c32_check_decode(c32_data):
+    c32_data = c32_normalize(c32_data)
+    data_hex = c32_decode(c32_data[1:])
+    version_char = c32_data[0]
+    version = C32.index(version_char)
+    checksum = data_hex[-8:]
+    version_hex = hex(version)[2:]
+    if len(version_hex) == 1:
+        version_hex = f'0{version_hex}'
+    
+    if (c32_checksum(f"{version_hex}{data_hex[:-8]}") != checksum):
+        raise ValueError('Invalid c32check string: checksum mismatch')
+    
+    return [version, data_hex[:-8]]
+
+
+def c32_normalize(c32_input):
+    return c32_input.upper().replace("O", "0").replace("L", "1").replace("I", "1")
+
+
+
 def c32_check_encode(version_enum, data):
     version = version_enum.value
     if version < 0 or version >= 32:

--- a/stackspy/common/clarity.py
+++ b/stackspy/common/clarity.py
@@ -1,0 +1,43 @@
+from .c32helpers import c32_address_decode
+from .helpers import StacksMessageType
+from enum import Enum
+
+class ClarityType(Enum):
+    Int = 0x00
+    UInt = 0x01
+    Buffer = 0x02
+    BoolTrue = 0x03
+    BoolFalse = 0x04
+    PrincipalStandard = 0x05
+    PrincipalContract = 0x06
+    ResponseOk = 0x07
+    ResponseErr = 0x08
+    OptionalNone = 0x09
+    OptionalSome = 0x0a
+    List = 0x0b
+    Tuple = 0x0c
+    StringASCII = 0x0d
+    StringUTF8 = 0x0e
+
+
+def create_address_from_c32_address_string(c32_address_string):
+    address_data = c32_address_decode(c32_address_string)
+    return {
+        "type": StacksMessageType.Address.value,
+        "version": address_data[0],
+        "hash160": address_data[1]
+    }
+
+def standard_principal_cv(address_string):
+    address = create_address_from_c32_address_string(address_string)
+    return {
+        "type": ClarityType.PrincipalStandard.value,
+        "address": address
+    }
+
+def prinicpal_cv(principal):
+    if "." in principal:
+        # TODO - Implement Contract Principal CV
+        return
+    else:
+        return standard_principal_cv(principal) 

--- a/stackspy/common/clarity.py
+++ b/stackspy/common/clarity.py
@@ -19,6 +19,7 @@ class ClarityType(Enum):
     StringASCII = 0x0d
     StringUTF8 = 0x0e
 
+MEMO_MAX_LENGTH_BYTES = 34
 
 def create_address_from_c32_address_string(c32_address_string):
     address_data = c32_address_decode(c32_address_string)
@@ -40,4 +41,16 @@ def prinicpal_cv(principal):
         # TODO - Implement Contract Principal CV
         return
     else:
-        return standard_principal_cv(principal) 
+        return standard_principal_cv(principal)
+
+def serialize_standard_principal_cv(princial_cv_data):
+    bytes_array = bytearray()
+    bytes_array.append(princial_cv_data["type"])
+    bytes_array += bytearray(princial_cv_data["address"]["version"].to_bytes(1, 'big'))
+    bytes_array += bytearray(bytes.fromhex(princial_cv_data["address"]["hash160"]))
+    return bytes_array
+
+def serialize_cv(cv_data):
+    if cv_data["type"] == ClarityType.PrincipalStandard.value:
+        return serialize_standard_principal_cv(cv_data)
+    # TODO - Implement other types

--- a/stackspy/common/derive.py
+++ b/stackspy/common/derive.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from helpers import compress_private_key
+from .helpers import compress_private_key
 import hashlib
 class DerivationType(Enum):
     Wallet = 1

--- a/stackspy/common/generate.py
+++ b/stackspy/common/generate.py
@@ -9,11 +9,11 @@ from cryptography.hazmat.backends import default_backend
 
 from binascii import hexlify, unhexlify
 from mnemonic import Mnemonic
-from derive import derive_wallet_keys, derive_account
-from wallet import Wallet
+from .derive import derive_wallet_keys, derive_account
+from .wallet import Wallet
 from bitcoinlib.keys import HDKey
-from account import Account
-from helpers import DerivationType, get_root_node
+from .account import Account
+from .helpers import DerivationType, get_root_node
 
 def generate_mnemonic(bits=256):
     """Generate a mnemonic phrase following BIP39 standards.

--- a/stackspy/common/helpers.py
+++ b/stackspy/common/helpers.py
@@ -1,10 +1,20 @@
-import numpy as np
-from binascii import unhexlify
 from enum import Enum
 from bitcoinlib.keys import HDKey
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes
+from secp256k1 import PrivateKey
+from constants import RECOVERABLE_ECDSA_SIG_LENGTH_BYTES, AuthType
 
 PRIVATE_KEY_COMPRESSED_LENGTH = 33
-
+MEMO_MAX_LENGTH_BYTES = 34 
+class PayloadType(Enum):
+    TokenTransfer = 0x00
+    SmartContract = 0x01
+    VersionedSmartContract = 0x06
+    ContractCall = 0x02
+    PoisonMicroblock = 0x03
+    Coinbase = 0x04
+    CoinbaseToAltRecipient = 0x05
 
 class StacksMessageType(Enum):
     Address = 0
@@ -20,7 +30,6 @@ class StacksMessageType(Enum):
     StructuredDataSignature = 10
     TransactionAuthField = 11
 
-
 class DerivationType(Enum):
     Wallet = 1
     Data = 2
@@ -28,7 +37,6 @@ class DerivationType(Enum):
 
 def get_root_node(wallet):
     return HDKey.from_wif(wallet.root_key)
-
 
 def compress_private_key(private_key_in_hex):
     private_key_bytes = bytearray.fromhex(private_key_in_hex)
@@ -48,3 +56,41 @@ def get_32_bytes_key(private_key_in_hex):
         return private_key_in_hex[:64]
     else:
         return private_key_in_hex
+
+def serialize_memo_string(memo_string: str):
+    # convert string to bytes
+    content_bytes = memo_string["content"].encode('utf-8')
+    # pad the hex string to the right
+    padded_content = content_bytes.hex().ljust(MEMO_MAX_LENGTH_BYTES * 2, '0')
+
+    return bytearray.fromhex(padded_content)
+
+def is_single_sig(spending_condition):
+    return "signature" in spending_condition
+
+def empty_signature_message():
+    return {
+        "type": StacksMessageType.MessageSignature,
+        "data": bytearray(RECOVERABLE_ECDSA_SIG_LENGTH_BYTES).hex()
+    }
+
+def sha512_256(data: bytes) -> bytes:
+    digest = hashes.Hash(hashes.SHA512_256(), backend=default_backend())
+    digest.update(data)
+    return digest.finalize()
+
+def left_pad_hex(hex_string: str) -> str:
+    return hex_string if len(hex_string) % 2 == 0 else '0' + hex_string    
+
+def is_hex_addy_compressed(hex_address):
+    return not hex_address.startswith('04')
+
+def pub_key_from_priv_key(private_key_32_bytes):
+    private_key = PrivateKey(privkey=bytes(bytearray.fromhex(get_32_bytes_key(private_key_32_bytes))), raw=True)
+    return private_key.pubkey.serialize().hex()
+
+def create_standard_auth(spending_condition):
+    return {
+        "authType": AuthType.Standard,
+        "spendingCondition": spending_condition
+    }

--- a/stackspy/common/helpers.py
+++ b/stackspy/common/helpers.py
@@ -5,6 +5,22 @@ from bitcoinlib.keys import HDKey
 
 PRIVATE_KEY_COMPRESSED_LENGTH = 33
 
+
+class StacksMessageType(Enum):
+    Address = 0
+    Principal = 1
+    LengthPrefixedString = 2
+    MemoString = 3
+    AssetInfo = 4
+    PostCondition = 5
+    PublicKey = 6
+    LengthPrefixedList = 7
+    Payload = 8
+    MessageSignature = 9
+    StructuredDataSignature = 10
+    TransactionAuthField = 11
+
+
 class DerivationType(Enum):
     Wallet = 1
     Data = 2

--- a/stackspy/constants.py
+++ b/stackspy/constants.py
@@ -7,3 +7,18 @@ class ChainID(Enum):
 class TransactionVersion(Enum):
   Mainnet = 0x00
   Testnet = 0x80
+
+class PubKeyEncoding(Enum):
+  Compressed = 0x00
+  Uncompressed = 0x01  
+
+class AuthType(Enum):
+  Standard = 0x04
+  Sponsored = 0x05
+
+class AnchorMode(Enum):
+  OnChainOnly = 0x01
+  OffChainOnly = 0x02
+  Any = 0x03
+
+RECOVERABLE_ECDSA_SIG_LENGTH_BYTES = 65

--- a/stackspy/network.py
+++ b/stackspy/network.py
@@ -38,7 +38,7 @@ class StacksNetwork:
 
     @staticmethod
     def fromNameOrNetwork(network):
-        if isinstance(network, str) and 'version' in network:
+        if isinstance(network, StacksNetwork) and network.version is not None:
             return network
         return StacksNetwork.fromName(network)
 
@@ -55,7 +55,7 @@ class StacksNetwork:
         return "{}{}".format(self.coreApiUrl, self.transactionFeeEstimateEndpoint)
 
     def getAccountApiUrl(self, address):
-        return "{}{}{}?proof=0".format(self.coreApiUrl, self.accountEndpoint, address)
+        return "{}{}/{}?proof=0".format(self.coreApiUrl, self.accountEndpoint, address)
 
     def getAccountExtendedBalancesApiUrl(self, address):
         return "{}/extended/v1/address/{}/balances".format(self.coreApiUrl, address)

--- a/stackspy/network.py
+++ b/stackspy/network.py
@@ -1,5 +1,5 @@
-from .constants import TransactionVersion, ChainID
-from .fetch import createFetchFn
+from constants import TransactionVersion, ChainID
+from fetch import createFetchFn
 
 HIRO_MAINNET_DEFAULT = 'https://stacks-node-api.mainnet.stacks.co'
 HIRO_TESTNET_DEFAULT = 'https://stacks-node-api.testnet.stacks.co'

--- a/stackspy/transactions.py
+++ b/stackspy/transactions.py
@@ -2,8 +2,13 @@ from secp256k1 import PrivateKey
 from enum import Enum
 import base32_lib as base32
 import hashlib
-from c32helpers import c32_address
-from helpers import get_32_bytes_key
+from common.c32helpers import c32_address
+from common.helpers import get_32_bytes_key, StacksMessageType
+from common.clarity import prinicpal_cv
+from network import StacksMainnet
+from common.StacksTransaction import StacksTransaction
+
+MEMO_MAX_LENGTH_BYTES = 34
 
 class TransactionVersion(Enum):
     Mainnet = 0x00
@@ -25,19 +30,15 @@ class AddressVersion(Enum):
     TestnetSingleSig = 26
     TestnetMultiSig = 21
 
-class StacksMessageType(Enum):
-    Address = 0
-    Principal = 1
-    LengthPrefixedString = 2
-    MemoString = 3
-    AssetInfo = 4
-    PostCondition = 5
-    PublicKey = 6
-    LengthPrefixedList = 7
-    Payload = 8
-    MessageSignature = 9
-    StructuredDataSignature = 10
-    TransactionAuthField = 11
+class PayloadType(Enum):
+    TokenTransfer = 0x00
+    SmartContract = 0x01
+    VersionedSmartContract = 0x06
+    ContractCall = 0x02
+    PoisonMicroblock = 0x03
+    Coinbase = 0x04
+    CoinbaseToAltRecipient = 0x05
+
 
 def get_address_from_private_key(private_key, transaction_version):
     pub_key = pub_key_from_priv_key(private_key)
@@ -79,7 +80,7 @@ def address_hash_mode_to_version(hash_mode: AddressHashMode, tx_version: Transac
 
 def address_from_version_hash(version, hash):
     return {
-        "type": StacksMessageType.Address,
+        "type": StacksMessageType.Address.value,
         "version": version,
         "hash160": hash
     }
@@ -89,3 +90,82 @@ def address_to_string(address):
 
 def get_stx_address(account, transaction_version = TransactionVersion.Testnet):
     return get_address_from_private_key(account.stx_private_key, transaction_version)
+
+
+def make_stx_token_transfer(tx_options):
+    if 'sender_key' in tx_options:
+        public_key = pub_key_from_priv_key(tx_options["sender_key"])
+        tx_options.pop("sender_key")
+        tx_options["public_key"] = public_key
+        transaction = make_unsigned_stx_token_transfer(tx_options)
+        print(transaction)
+
+def create_memo_string(memo_content):
+    if len(memo_content.encode('utf-8')) > MEMO_MAX_LENGTH_BYTES:
+        raise ValueError('Memo exceeds maximum length of '+MEMO_MAX_LENGTH_BYTES+' bytes')
+    return { "type": StacksMessageType.MemoString.value, "content": memo_content };
+
+
+def create_token_transfer_payload(recipient, amount, memo=None):
+    recipient = prinicpal_cv(recipient)
+    memo = create_memo_string(memo)
+    print(recipient)
+    print(memo)
+    return {
+        "type": StacksMessageType.Payload.value,
+        "payloadType": PayloadType.TokenTransfer.value,
+        "recipient": recipient,
+        "amount": amount,
+        "memo": memo or create_memo_string("")
+    }
+
+def estimate_transaction_byte_length(transaction):
+    # TODO - SERIALIZE INTO BYTES AND RETUR LENGTH
+    return 0
+
+def estimate_transaction_fee_with_fallback(transaction, network):
+    estimated_len = estimate_transaction_byte_length(transaction)
+    # TODO - Continue from here.
+
+def make_unsigned_stx_token_transfer(tx_options):
+    options = {
+        "fee": 0,
+        "nonce": 0,
+        "network": StacksMainnet(),
+        "memo": "",
+        "sponsored": False
+    }
+
+    options.update(tx_options)
+    payload = create_token_transfer_payload(options["recipient"], options["amount"], options["memo"])
+    print(payload)
+    authorization = None
+    spending_condition = None
+
+    # TODO - Implement:
+    if 'public_key' in options:
+        pass
+    else:
+        pass
+
+    # TODO - Implement
+    if options["sponsored"]:
+        pass
+    else:
+        pass
+
+    # TODO - optionally get network from name
+    network = options["network"]
+
+    transaction = StacksTransaction(
+        network.version.value, #value or enum?
+        authorization,
+        payload,
+        None,
+        None,
+        options["anchor_mode"],
+        network.chainId.value #value or enum
+    )
+
+    if ("fee" not in tx_options):
+        fee = estimate_transaction_fee_with_fallback(transaction, network)


### PR DESCRIPTION
Adding StacksTransaction.
- Single Sig + Sender Key 
- Focus on implementing make_stx_token_transfer
- Able to successfully serialize transaction [same output as stacks.js]


Example code for transactions:

```
from network import StacksTestnet
from transactions import make_stx_token_transfer
network = StacksTestnet()
tx_options = {
    "recipient": 'ST319CF5WV77KYR1H3GT0GZ7B8Q4AQPY42ETP1VPF',
    "sender_key": "b244296d5907de9864c0b0d51f98a13c52890be0404e83f273144cd5b9960eed01",
    "network": network,
    "memo": "hello from python",
    "amount": 10
}
transaction = make_stx_token_transfer(tx_options)
print(transaction.serialize().hex())
```



TODO - test broadcasting [waiting for faucet]